### PR TITLE
ci: Reset GitHub Pages workflow to match upstream

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -5,9 +5,9 @@
 name: Deploy mdBook site to Pages
 
 on:
-  # Runs on pushes targeting the default branch or the docs/fix-github-pages branch
+  # Runs on pushes targeting the default branch
   push:
-    branches: ["main", "docs/fix-github-pages"]
+    branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -28,8 +28,7 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
-    # Allow running on forks for testing
-    # if: github.event.repository.fork == false
+    if: github.event.repository.fork == false
     env:
       MDBOOK_VERSION: 0.4.36
     steps:
@@ -52,8 +51,7 @@ jobs:
   # Deployment job
   deploy:
     runs-on: ubuntu-latest
-    # Allow running on forks for testing
-    # if: github.event.repository.fork == false
+    if: github.event.repository.fork == false
     needs: build
     environment:
       name: github-pages


### PR DESCRIPTION
This PR resets the GitHub Pages workflow configuration to match the upstream repository.

Changes:
- Restore the original workflow configuration from the upstream repository
- Remove custom branch triggers that were added for testing
- Re-enable the fork check to prevent deployment from forks

This ensures our fork maintains compatibility with the upstream repository's CI/CD pipeline.

🤖 Assisted by [Amazon Q Developer](https://aws.amazon.com/q/developer)